### PR TITLE
Added option to filter which issues to process by label

### DIFF
--- a/github_bot.yml
+++ b/github_bot.yml
@@ -16,6 +16,9 @@ schedule:
 # label to add to issues when closing automatically (optional)
 # label: inactive
 
+# label to filter which issues to process (optional)
+# filterlabel: bug
+
 # issue warnings instead of closing until this date (optional)
 # first_closing_date: 2017-03-01 12:00:00
 

--- a/github_bot_close_inactive_issues/close_inactive_issues.py
+++ b/github_bot_close_inactive_issues/close_inactive_issues.py
@@ -11,7 +11,11 @@ def process_issues(config):
     conn = connect(config)
     rate_limit(config)
     repo = conn.get_repo(config["repo"])
-    issues = repo.get_issues(state="open")
+    if "filterlabel" not in config:
+        issues = repo.get_issues(state="open")
+    else:
+        logging.info("Label filter specified. Only processing issues with label \"{}\"".format(config["filterlabel"]))
+        issues = repo.get_issues(state="open", labels=[repo.get_label(config["filterlabel"])])
     schedule = config["schedule"]
     warning_start = schedule["warning_start"]
     warning_frequency = schedule["warning_frequency"]
@@ -68,6 +72,7 @@ def main(argv=None):
     parser.add_argument('--token', action="store", help='Github token')
     parser.add_argument('--repo', action="store", help='Repository')
     parser.add_argument('--label', action="store", help='Add this label to issues when closing')
+    parser.add_argument('--filter-label', action="store", help='Only process issues that have this label')
     parser.add_argument('--test', action="store_true",
                         help='Print actions that would be taken but do not modify repository')
     args = parser.parse_args(argv)
@@ -84,6 +89,8 @@ def main(argv=None):
         config["test"] = True
     if args.label:
         config["label"] = args.label
+    if args.filter_label:
+        config["filterlabel"] = args.filter_label
     if "label" not in config:
         config["label"] = None
     start_logging(config)


### PR DESCRIPTION
Hi. I added a new option that allows users to specify a label which will be used as a filter when processing open issues. This is similar to the "ignore-label" option, except it works the other way around.

In one of our repositories, we manually tag issues that are pending requester input. We want to close any such issues after a certain period (but we don't want to close any other). We use several other tags, so manually maintaining an "ignore-label" list was not the best way to go for us.